### PR TITLE
Fix Live Scoreboard Load

### DIFF
--- a/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
@@ -23,6 +23,12 @@
   </div>
 </div>
 <script>
+  
+  setTimeout(function() {
+        results = <%- JSON.stringify(locals.liveResults) %>;
+        updateScores(results);
+      }, 500);
+
   const courseInstanceId = '<%= course_instance.id %>';
   const source = new EventSource(`/pl/course_instance/${courseInstanceId}/plrStudent/live_updates`);
 

--- a/apps/prairielearn/src/pages/plrStudent/plrStudent.js
+++ b/apps/prairielearn/src/pages/plrStudent/plrStudent.js
@@ -35,12 +35,15 @@ router.get('/', function (req, res, next) {
     res.locals.seasonalResults = seasonalResults;
   });
   
+  console.log('Sanity Check 1');
   getLiveResults(course_instance_id, function (err, liveResults) {
     if (ERR(err, next)) return;
     res.locals.liveResults = liveResults;
   });
-  
-  res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+
+  setTimeout(function() {
+    res.render(__filename.replace(/\.js$/, '.ejs'), res.locals);
+  }, 500);
 });
 
 // ---------


### PR DESCRIPTION
The communication needed timeouts since the page loads faster than the database can respond.

Also needed to fix how the two pages were communicating.

There needs to be some sort of safeguard here checking if live scoreboard is populated (idk if it'll throw an error if it's not).

And Im also unsure if a trigger from the db will update correctly or add duplicate rows. It shouldn't since they use the same function.

This fixed the bug but a lot more needs to be cleaned up in the cleanup card essentially.

https://github.com/UBCO-COSC-499-Summer-2023/PrairieLearn-Gamification/pull/296