### PR TITLE
Fixing the bug with the "time.seconds" call.

### DIFF
--- a/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
@@ -89,7 +89,7 @@
       if (time.seconds == undefined){
         timeCell.textContent = "00:00";
       } else if (time.minutes == undefined) {
-        var formattedSeconds = seconds < 10 ? `0${time.seconds}` : String(time.seconds);
+        var formattedSeconds = time.seconds < 10 ? `0${time.seconds}` : String(time.seconds);
         timeCell.textContent = `00:${formattedSeconds}`;
       } else {
         var formattedMinutes = time.minutes < 10 ? `0${time.minutes}` : String(time.minutes);


### PR DESCRIPTION
https://github.com/LouisLP/PrairieLearn-Ranked/pull/36
https://github.com/UBCO-COSC-499-Summer-2023/PrairieLearn-Gamification/pull/350
<img width="876" alt="image" src="https://github.com/LouisLP/PrairieLearn-Ranked/assets/13853873/366ab213-b95f-43ba-ae9c-8004aef53bb2">
