### PR TITLE
Fix number formatting

### DIFF
--- a/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
@@ -34,7 +34,7 @@
               <% } %> 
               </td>         
               <!-- TOTAL SCORE -->   
-              <td><%= locals.allTimeResults[i].points %></td>
+              <td><%= locals.allTimeResults[i].points.toLocaleString("en-US") %></td>
               <!-- YEAR -->
               <td><%= (new Date(locals.allTimeResults[i].created_at)).getFullYear() %></td>
             </tr>

--- a/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
@@ -90,7 +90,7 @@
       rankCell.setAttribute('scope', 'row');
       rankCell.textContent = score.rank;
       nameCell.textContent = score.display_name;
-      scoreCell.textContent = score.points;
+      scoreCell.textContent = score.points.toLocaleString("en-US");
 
       // Create achievement and time cells (done in functions)
       const achievementCell = createAchievementCell(score.achievements);

--- a/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
@@ -33,7 +33,7 @@
                 <% } %>                           
               </td>         
               <!-- TOTAL SCORE -->   
-              <td><%= locals.seasonalResults[i].points %></td>
+              <td><%= locals.seasonalResults[i].points.toLocaleString("en-US") %></td>
             </tr>
           <% } %>
         <% } else { %>


### PR DESCRIPTION
Updated it so all 3 scoreboards have commas and nicer number formatting.

Live Scoreboard:
![LiveScoreboard](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/e94235f6-9edd-4399-b2ca-67b6b5249814)


Seasonal Scoreboard:
![SeasonalScoreboard](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/d870d049-f82d-4dfc-b651-00cd02e64f66)


All-Time Scoreboard:
![AllTimeScoreboard](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/aa56d8a0-97c2-4073-b660-6120672d15d7)

https://github.com/UBCO-COSC-499-Summer-2023/PrairieLearn-Gamification/pull/402