### PR TITLE
Fix No Results Bug

### DIFF
--- a/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
@@ -16,7 +16,7 @@
         </tr>
       </thead>
       <tbody>
-        <% if (locals.allTimeResults) { %>
+        <% if (locals.allTimeResults.length > 0) { %>
           <% for(let i = 0; i < locals.allTimeResults.length; i++) { %>
             <tr>
               <!-- RANK -->

--- a/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
@@ -15,7 +15,7 @@
         </tr>
       </thead>
       <tbody>
-        <% if (locals.seasonalResults) { %>
+        <% if (locals.seasonalResults.length > 0) { %>
           <% for(let i = 0; i < locals.seasonalResults.length; i++) { %>
             <tr>
               <!-- RANK -->


### PR DESCRIPTION
All that needed to be changed was instead of checking if the variable existed (because it always does) was to check the length.

This is showing the seasonal scoreboard displaying no results:
![SeasonalScoreboard](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/b61069b0-bffa-4c7d-9f4e-3eccefe4a8e5)

This is showing the all-time scoreboard displaying no results:
![AllTimeScoreboard](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/43cabe2d-0f44-4820-b005-09cfc89490b2)

Then this is showing that the seasonal scoreboard still displays properly with results:
![SeasonalStillWorks](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/59d3f9fb-f383-4678-a3a9-46fa41a4d004)

Then this is showing that the all-time scoreboard still displays properly with results:
![AllTimeStillWorks](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/7df7339f-15ae-484f-af4d-cb3c9c8556e4)

https://github.com/UBCO-COSC-499-Summer-2023/PrairieLearn-Gamification/pull/403