### PR TITLE
Fix Display

### DIFF
--- a/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/allTimeScoreboard.ejs
@@ -30,7 +30,7 @@
                       <span class="material-symbols-outlined align-bottom"><%= achievement %></span>
                   <% }); %>
               <% } else { %> 
-                  <p>No badges earned.</p>
+                  <p>No achievements earned.</p>
               <% } %> 
               </td>         
               <!-- TOTAL SCORE -->   

--- a/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
@@ -150,7 +150,7 @@
       });
     } else {
       const noBadgeParagraph = document.createElement('p');
-      noBadgeParagraph.textContent = 'No badges earned.';
+      noBadgeParagraph.textContent = 'No achievements earned.';
       achievementCell.appendChild(noBadgeParagraph);
     }
     return achievementCell;

--- a/apps/prairielearn/src/pages/partials/plr/plrScoreboard.sql
+++ b/apps/prairielearn/src/pages/partials/plr/plrScoreboard.sql
@@ -7,7 +7,8 @@ SELECT
       FROM PLR_achievements
       JOIN PLR_has_achieved ON PLR_achievements.id = PLR_has_achieved.achievement_id
       WHERE PLR_has_achieved.user_id = PLR_students.user_id
-   ) AS achievements
+   ) AS achievements,
+   PLR_students.user_id AS user_id
 FROM
    PLR_seasonal_session_CREDENTIALS
    JOIN PLR_students USING (user_id)

--- a/apps/prairielearn/src/pages/partials/plr/profileCard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/profileCard.ejs
@@ -29,16 +29,23 @@
     <div class="col my-auto">
       <h5>Achieved</h5>
     <% if (locals.seasonalResults) { %>
+      <% var foundFlag = false; %>
       <% for(let i = 0; i < locals.seasonalResults.length; i++) { %>
           <!-- ACHIEVEMENTS/BADGES -->
-            <% if (locals.seasonalResults[i].achievements) { %>
+            <% if (locals.seasonalResults[i].achievements && locals.seasonalResults[i].user_id == locals.userId) { %>
+              <script>
+                console.log('SanityCheck1');
+                console.log(<%- JSON.stringify(locals.seasonalResults[i].achievements && locals.seasonalResults[i].user_id == locals.userId)%>)
+              </script>
                 <% locals.seasonalResults[i].achievements.forEach((achievement) => { %>
                     <span class="material-symbols-outlined align-bottom pr-2"><%= achievement %></span>
                 <% }); %>
-            <% } else { %> 
-                <p>No achievements earned.</p>
-            <% } %>    
-      <% } %>
+                <% foundFlag = true; %>
+            <% } %>
+          <% } %>
+          <% if (!foundFlag){%>
+            <p>No achievements earned</p>
+          <% } %>
     <% } else { %>
       <p>No results found.</p>
     <% } %>

--- a/apps/prairielearn/src/pages/partials/plr/profileCard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/profileCard.ejs
@@ -33,10 +33,6 @@
       <% for(let i = 0; i < locals.seasonalResults.length; i++) { %>
           <!-- ACHIEVEMENTS/BADGES -->
             <% if (locals.seasonalResults[i].achievements && locals.seasonalResults[i].user_id == locals.userId) { %>
-              <script>
-                console.log('SanityCheck1');
-                console.log(<%- JSON.stringify(locals.seasonalResults[i].achievements && locals.seasonalResults[i].user_id == locals.userId)%>)
-              </script>
                 <% locals.seasonalResults[i].achievements.forEach((achievement) => { %>
                     <span class="material-symbols-outlined align-bottom pr-2"><%= achievement %></span>
                 <% }); %>

--- a/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/seasonalScoreboard.ejs
@@ -29,7 +29,7 @@
                         <span class="material-symbols-outlined align-bottom"><%= achievement %></span>
                     <% }); %>
                 <% } else { %> 
-                    <p>No badges earned.</p>
+                    <p>No achievements earned.</p>
                 <% } %>                           
               </td>         
               <!-- TOTAL SCORE -->   


### PR DESCRIPTION
Fixed the bug where it would display all users achievements. Needed to pass in a user_id from the backend to attach the achievements too. Then needed to add to the if statement to double check if the user lined up.

Since we were iterating through the badges it would display No badges earned for all other users, so I added a flag and an if statement to work around that.

Here is proof that it is populating correctly:
![AllFixed](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/c9e49e74-6a6d-4051-a3b7-62cf6f8fbc06)

Here is proof that it still displays no badges:
![NoBadges](https://github.com/rlawrenc/PrairieLearn-Ranked/assets/71582228/a534921e-ce9a-49ee-a4b5-39365ebeab20)

https://github.com/UBCO-COSC-499-Summer-2023/PrairieLearn-Gamification/pull/410