### PR TITLE
Trigger Updates

### DIFF
--- a/apps/prairielearn/src/migrations/20230716010045_PLR_trigger_insert_update_score_duration_and_rank.sql
+++ b/apps/prairielearn/src/migrations/20230716010045_PLR_trigger_insert_update_score_duration_and_rank.sql
@@ -1,6 +1,5 @@
 -- This trigger updates the score, duration, and rank for students in the live session.
-CREATE
-OR REPLACE FUNCTION update_score_and_rank () RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION update_score_and_rank () RETURNS TRIGGER AS $$
 BEGIN
   -- First thing we do is check if the student has already started an assessment instance in the live session.
   IF NEW.id IN (
@@ -8,7 +7,7 @@ BEGIN
     FROM PLR_live_session_credentials
     WHERE PLR_live_session_credentials.user_id = NEW.user_id
   ) THEN
-    --If they have, we update their score and duration.
+    -- If they have, we update their score and duration.
     UPDATE PLR_live_session_credentials
     SET
       points = NEW.points * 1000,
@@ -37,24 +36,34 @@ BEGIN
       assessments.id = NEW.assessment_id AND is_live = TRUE;
   END IF;
 
-  -- This query updates the rank of each student in the live session.
-  -- RL UPDATE: Updating the rank has been removed as it results in deadlock due to
-  -- reading the entire PLR_live_session_credentials table then updating the rows
-  -- Deadlock can occur when two separate users (trigger invocations) cause the read and write to happen concurrently
-  -- WITH RankedTable AS (
-  --   SELECT
-  --     id,
-  --     session_id,
-  --     user_id,
-  --     RANK() OVER (PARTITION BY session_id ORDER BY points DESC, duration ASC) AS new_rank
-  --   FROM
-  --     PLR_live_session_credentials
-  -- )
-  -- This sets the rank of each student in the live session to the rank in the RankedTable.
-  -- UPDATE PLR_live_session_credentials AS target
-  -- SET rank = subquery.new_rank
-  -- FROM RankedTable AS subquery
-  -- WHERE target.id = subquery.id;
+  -- DANGER: This trigger can be commented-out entirely if continuing to cause issues.
+
+  -- September 2023 Dr. Ramon Lawrence update:
+  -- Updating the rank has been removed as it results in deadlock due to reading the entire PLR_live_session_credentials table then updating the rows. Deadlock can occur when two separate users (trigger invocations) cause the read and write to happen concurrently.
+
+  -- October 2023 Louis Lascelles-Palys update:
+  -- Updating the rank has been reimplemented using advisory locks to prevent deadlock.
+  -- "pg_try_advisory_xact_lock(1)" doesn't wait (skips the operation)
+  -- "pg_advisory_xact_lock(1)" waits for the previous transaction to finish
+
+  -- Try to acquire an advisory lock, proceed if successful
+  IF pg_try_advisory_xact_lock(1) THEN
+    -- This query updates the rank of each student in the live session.
+    WITH RankedTable AS (
+      SELECT
+        id,
+        session_id,
+        user_id,
+        RANK() OVER (PARTITION BY session_id ORDER BY points DESC, duration ASC) AS new_rank
+      FROM
+        PLR_live_session_credentials
+    )
+    -- This sets the rank of each student in the live session to the rank in the RankedTable.
+    UPDATE PLR_live_session_credentials AS target
+    SET rank = subquery.new_rank
+    FROM RankedTable AS subquery
+    WHERE target.id = subquery.id;
+  END IF;
 
   RETURN NEW;
 END;
@@ -62,7 +71,5 @@ $$ LANGUAGE plpgsql;
 
 -- This trigger listens for updates or inserts on assessment instances
 CREATE TRIGGER trigger_update_assessment_instances
-AFTER
-UPDATE
-OR INSERT ON assessment_instances FOR EACH ROW
+AFTER UPDATE OR INSERT ON assessment_instances FOR EACH ROW
 EXECUTE FUNCTION update_score_and_rank ();

--- a/apps/prairielearn/src/migrations/20230812180255_PLR_inserts.sql
+++ b/apps/prairielearn/src/migrations/20230812180255_PLR_inserts.sql
@@ -1,5 +1,4 @@
 -- Moved all the inserts here to ensure that they are run after the tables are created.
-
 -- Insert our pre-made achievements into the achievements table
 INSERT INTO
   PLR_achievements (
@@ -50,22 +49,26 @@ VALUES
   );
 
 -- This insert will grab every student in the DB when the table is made.
---- INSERT INTO PLR_students (user_id, display_name)
--- SELECT 
---     user_id, name
--- FROM
---     users
--- WHERE
---     user_id NOT IN (
---         SELECT
---             user_id
---         FROM
---             job_sequences
---     );
+INSERT INTO PLR_students (user_id, display_name)
+SELECT 
+    user_id, name
+FROM
+    users
+WHERE
+    user_id NOT IN (
+        SELECT
+            user_id
+        FROM
+            job_sequences
+    )
+ON CONFLICT (user_id) DO NOTHING;
 
 -- This insert will grab every student's enrollment in the DB when the table is made.
--- INSERT INTO PLR_enrollment (user_id, course_instance_id)
--- SELECT 
---     user_id, course_instance_id
--- FROM
---     enrollments;
+INSERT INTO
+  PLR_enrollment (user_id, course_instance_id)
+SELECT
+  user_id,
+  course_instance_id
+FROM
+  enrollments
+ON CONFLICT (user_id, course_instance_id) DO NOTHING;


### PR DESCRIPTION
Two main (hopefully) fixes here:

1. The trigger that updates the scores and ranks of students should now be using an **advisory lock**. This should prevent deadlock, and instead make rank updates a bit more occasional.
2. The initial `insert` statements when restarting the system have a "ON CONFLICT DO NOTHING" statement now. 