### PR TITLE
Trigger Updates (ordering, and score/rank updates)

### DIFF
--- a/apps/prairielearn/src/migrations/20230716010045_PLR_trigger_insert_update_score_duration_and_rank.sql
+++ b/apps/prairielearn/src/migrations/20230716010045_PLR_trigger_insert_update_score_duration_and_rank.sql
@@ -1,5 +1,8 @@
+----------------------
+-- UPDATING THE SCORES
+----------------------
 -- This trigger updates the score, duration, and rank for students in the live session.
-CREATE OR REPLACE FUNCTION update_score_and_rank () RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION update_score () RETURNS TRIGGER AS $$
 BEGIN
   -- First thing we do is check if the student has already started an assessment instance in the live session.
   IF NEW.id IN (
@@ -35,41 +38,43 @@ BEGIN
     WHERE
       assessments.id = NEW.assessment_id AND is_live = TRUE;
   END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
-  -- DANGER: This trigger can be commented-out entirely if continuing to cause issues.
+-- Trigger to update the score and duration after each question is answered
+CREATE TRIGGER trigger_update_score
+AFTER UPDATE OR INSERT ON assessment_instances FOR EACH ROW
+EXECUTE FUNCTION update_score();
 
-  -- September 2023 Dr. Ramon Lawrence update:
-  -- Updating the rank has been removed as it results in deadlock due to reading the entire PLR_live_session_credentials table then updating the rows. Deadlock can occur when two separate users (trigger invocations) cause the read and write to happen concurrently.
-
-  -- October 2023 Louis Lascelles-Palys update:
-  -- Updating the rank has been reimplemented using advisory locks to prevent deadlock.
-  -- "pg_try_advisory_xact_lock(1)" doesn't wait (skips the operation)
-  -- "pg_advisory_xact_lock(1)" waits for the previous transaction to finish
-
-  -- Try to acquire an advisory lock, proceed if successful
-  IF pg_try_advisory_xact_lock(1) THEN
-    -- This query updates the rank of each student in the live session.
-    WITH RankedTable AS (
-      SELECT
-        id,
-        session_id,
-        user_id,
-        RANK() OVER (PARTITION BY session_id ORDER BY points DESC, duration ASC) AS new_rank
-      FROM
-        PLR_live_session_credentials
-    )
-    -- This sets the rank of each student in the live session to the rank in the RankedTable.
-    UPDATE PLR_live_session_credentials AS target
-    SET rank = subquery.new_rank
-    FROM RankedTable AS subquery
-    WHERE target.id = subquery.id;
-  END IF;
+---------------------
+-- UPDATING THE RANKS
+---------------------
+-- Function to update the final rank
+CREATE OR REPLACE FUNCTION update_final_rank () RETURNS TRIGGER AS $$
+BEGIN
+  -- This query updates the rank of each student in the live session.
+  WITH RankedTable AS (
+    SELECT
+      id,
+      session_id,
+      user_id,
+      RANK() OVER (PARTITION BY session_id ORDER BY points DESC, duration ASC) AS new_rank
+    FROM
+      PLR_live_session_credentials
+  )
+  -- This sets the rank of each student in the live session to the rank in the RankedTable.
+  UPDATE PLR_live_session_credentials AS target
+  SET rank = subquery.new_rank
+  FROM RankedTable AS subquery
+  WHERE target.id = subquery.id;
 
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- This trigger listens for updates or inserts on assessment instances
-CREATE TRIGGER trigger_update_assessment_instances
-AFTER UPDATE OR INSERT ON assessment_instances FOR EACH ROW
-EXECUTE FUNCTION update_score_and_rank ();
+-- Trigger to update the final rank when the live session ends
+CREATE TRIGGER trigger_update_final_rank
+AFTER UPDATE ON PLR_live_session FOR EACH ROW
+WHEN (OLD.is_live IS TRUE AND NEW.is_live IS FALSE)
+EXECUTE FUNCTION update_final_rank();

--- a/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
+++ b/apps/prairielearn/src/pages/partials/plr/liveScoreboard.ejs
@@ -88,7 +88,7 @@
 
       // Set the content of each cell
       rankCell.setAttribute('scope', 'row');
-      rankCell.textContent = score.rank;
+      rankCell.textContent = index + 1;
       nameCell.textContent = score.display_name;
       scoreCell.textContent = Math.round(score.points).toLocaleString("en-US");
 

--- a/apps/prairielearn/src/pages/partials/plr/plrScoreboard.sql
+++ b/apps/prairielearn/src/pages/partials/plr/plrScoreboard.sql
@@ -59,5 +59,5 @@ FROM
 WHERE
    is_live = TRUE
 ORDER BY
-   rank ASC;
+   points DESC, duration ASC;
 -- ENDBLOCK

--- a/apps/prairielearn/src/pages/plrStaff/plrStaff.sql
+++ b/apps/prairielearn/src/pages/plrStaff/plrStaff.sql
@@ -8,7 +8,9 @@ FROM
    JOIN assessment_sets ON assessments.assessment_set_id = assessment_sets.id
 WHERE
    assessment_sets.abbreviation = 'LV'
-   AND assessments.course_instance_id = $1;
+   AND assessments.course_instance_id = $1
+ORDER BY
+   assessments.title ASC;
 
 -- ENDBLOCK
 


### PR DESCRIPTION
Following up on #65...
- There should be an `ORDER BY` clause when displaying the list of available live assessments (as currently, the list is very long and disorganized)
- The score/rank update triggers should be done ONCE at the end of the live assessment. DURING the live assessment, rank-sorting should just be done on the frontend.

This second point is more involved, so I describe it in more [detail below](https://github.com/rlawrenc/PrairieLearn-Ranked/pull/67#issuecomment-1752152483).