### PR TITLE
Flake8 Config File

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+max-line-length = 120
+ignore = E203, E266, E501, W503, C901
+max-complexity = 18
+select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
Especially in the `.py` files, there's a strange configuration of [Flake8](https://flake8.pycqa.org/en/latest/) that brings up a ton of warnings, and causes very short line lengths (maximum 80 characters). To avoid this, I added a config file to our root directory which should ignore a lot of these.